### PR TITLE
crontab task fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ sudo apt-get install astra-ad-sssd-client && astra-ad-sssd-client -d example.ru 
 
 Для Debian и Astra Linux: 
 ```
-sudo apt-get install dnsutils
+sudo apt-get install dnsutils, iputils-arping
 ```
 Для Red Hat Enterprise Linux:
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ DNSCP использует функцию обратных вызовов ([call
 #### Операционные Системы:
 - **Debian**: 9, 10, 11
 - **Astra Linux**: Common Edition (основан на Debian 9), Spetial Edition (основан на Debian 10)
+- **РЕД ОС**: 8
 - **Red Hat Enterprise Linux**: 7.x и выше (протестировано на RHEL 7.9)
 
 #### Patroni:
@@ -152,7 +153,7 @@ postgres  ALL=(ALL)       NOPASSWD: /sbin/net ads *, /sbin/ip address *, /bin/cr
 
 Вы можете запускать скрипт вручную в тестовых целях, имитируя запуск от Patroni следующей командой:
 ```
-sudo /etc/patroni/dnscp.sh -vips '192.168.10.100' -pwdfile '/etc/patroni/dnscp.secret' -- " on_role_change primary pgsql
+sudo /etc/patroni/dnscp.sh -vips '192.168.10.100' -pwdfile '/etc/patroni/dnscp.secret' -- on_role_change primary pgsql
 ```
 Подробнее о работе скрипта смотрите в комментариях к коду в файле [dnscp.sh](./dnscp.sh).  
 [Подробнее о Patroni callback](https://patroni.readthedocs.io/en/latest/SETTINGS.html)

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ DNSCP использует функцию обратных вызовов ([call
 
 #### Операционные Системы:
 - **Debian**: 9, 10, 11
-- **Astra Linux**: Common Edition (основан на Debian 9), Spetial Edition (основан на Debian 10)
-- **РЕД ОС**: 8
+- **Astra Linux**: Common Edition 2.12 (основан на Debian 9), Spetial Edition 1.7 (основан на Debian 10)
 - **Red Hat Enterprise Linux**: 7.x и выше (протестировано на RHEL 7.9)
 
 #### Patroni:
@@ -37,8 +36,6 @@ DNSCP использует функцию обратных вызовов ([call
 
 #### Службы каталога:
 - **Microsoft Active Directory**: :white_check_mark:
-- **Astra Linux [Directory](https://astralinux.ru/products/ald-pro)**: ожидается..
-- **РЕД СОФТ Samba DC**: ожидается..
 
 ## Требования
 Скрипт требует привилегий root или sudo и запускается сервисом Patroni.

--- a/dnscp.sh
+++ b/dnscp.sh
@@ -7,7 +7,7 @@
 
 readonly productname="DNS Connection Point for Patroni";
 readonly giturl="https://github.com/IlgizMamyshev/dnscp";
-readonly version="18062023";
+readonly version="23062024";
 
 ### Script for Patroni clusters
 # Script Features:
@@ -15,20 +15,23 @@ readonly version="18062023";
 # * Remove VIP address from network interface if Patroni stop or switch to non-Leader role
 # * Register\Update DNS A-record for PostgreSQL client access
 
-### Installing script
+### Installation
 # * Enable using callbacks in Patroni configuration (/etc/patroni/patroni.yml):
 #postgresql:
 #  callbacks:
 #    on_start: "/etc/patroni/dnscp.sh -vips '<VIPs>' -pwdfile '/etc/patroni/dnscp.secret' -- "
-#    on_stop: /etc/patroni/dnscp.sh "/etc/patroni/dnscp.sh -vips '<VIPs>' -pwdfile '/etc/patroni/dnscp.secret' -- "
-#    on_role_change: /etc/patroni/dnscp.sh "/etc/patroni/dnscp.sh -vips '<VIPs>' -pwdfile '/etc/patroni/dnscp.secret' -- "
+#    on_stop:  "/etc/patroni/dnscp.sh -vips '<VIPs>' -pwdfile '/etc/patroni/dnscp.secret' -- "
+#    on_role_change: "/etc/patroni/dnscp.sh -vips '<VIPs>' -pwdfile '/etc/patroni/dnscp.secret' -- "
 # * Put script to "/etc/patroni/dnscp.sh" and set executable (adds the execute permission for all users to the existing permissions.):
 #   sudo mv dnscp.sh /etc/patroni/dnscp.sh && sudo chmod ugo+x /etc/patroni/dnscp.sh
 # * View command for dnsupdate:
 #   sudo cat /var/spool/cron/crontabs/postgres
 
-### Operation System prerequisites
-# * Astra Linux (Debian or compatible)
+### Operation Systems supported
+# * Astra Linux
+# * RED OS
+# * Debian
+# * Ubuntu
 # * Red Hat Enterprise Linux
 
 ### PostgreSQL prerequisites
@@ -351,7 +354,7 @@ else
                 fi
 
                 # Remove cron task
-                sudo crontab -u $(whoami) -l | grep -v "$0" | sudo crontab -u $(whoami) -
+                crontab -u $(whoami) -l | grep -v "$SCRIPTNAME" | crontab -u $(whoami) -
             else
                 if [[ $VERBOSE -eq 1 ]]; then echo "[$LOGHEADER] INFO: VIP $VIP not exist, no action required."; fi
             fi
@@ -414,7 +417,7 @@ else
                     fi
 
                     # Remove cron task
-                    sudo crontab -u $(whoami) -l | grep -v "$0" | sudo crontab -u $(whoami) -
+                    crontab -u $(whoami) -l | grep -v "$SCRIPTNAME" | crontab -u $(whoami) -
                 else
                     if [[ $VERBOSE -eq 1 ]]; then echo "[$LOGHEADER] INFO: VIP $VIP not exist, no action required."; fi
                 fi
@@ -463,7 +466,7 @@ else
             # Enable DNS Update cron task if service_ip exists
             #####################################################
             # Remove cron task
-            sudo crontab -u $(whoami) -l | grep -v "$0" | sudo crontab -u $(whoami) -
+            crontab -u $(whoami) -l | grep -v "$SCRIPTNAME" | crontab -u $(whoami) -
             if [[ -z $(ip address | awk '/'$VIP'/{print $0}') ]]; then
                 # service_ip not exists
                 if [[ $VERBOSE -eq 1 ]]; then
@@ -472,7 +475,7 @@ else
                 fi
             else
                 # service_ip exists - Add cron task for Dynamic DNS Updates
-                sudo crontab -u $(whoami) -l 2>/dev/null; echo "53 00 * * * $0 -vips '$VIPs' -pwdfile '$VCompPasswordFile' -dnszonefqdn '$DNSzoneFQDN' -dnsserver '$DNSserver' -ttl '$TTL' -- on_schedule registerdns $VCompName" | sudo crontab -u $(whoami) -
+                (crontab -u $(whoami) -l 2>/dev/null; echo "53 00 * * * $0 -vips '$VIPs' -pwdfile '$VCompPasswordFile' -dnszonefqdn '$DNSzoneFQDN' -dnsserver '$DNSserver' -ttl '$TTL' -- on_schedule registerdns $VCompName") | crontab -u $(whoami) -
                 echo "[$LOGHEADER] INFO: 'Dynamic DNS Update' cron task for $(whoami) user (re)enabled.";
             fi
             ;;


### PR DESCRIPTION
Когда происходило добавление или удаление задачи crontab, происходило удаление всех ранее возможно существовавших задач crontab для текущего пользователя (обычно postgres), в контексте которого работает patroni и callback-скрипт.
Теперь происходит действительно добавление и удаление задачи только от callback-скрипта, другие существующие задачи crontab для текущего пользователя сохраняются.